### PR TITLE
Edit problematic card JSON syntax

### DIFF
--- a/src/data/cards/beast-hardheaded.txt
+++ b/src/data/cards/beast-hardheaded.txt
@@ -14,9 +14,9 @@
       "Prince"
     ],
     "set-code": "TFC",
-    "abilities": {"Break": "When you play this character, you may banish chosen item card."},
+    "abilities": {"Break": "When you play this character, you may banish chosen item."},
     "inkable": true,
-    "body-text": "BREAK: When you play this character, you may banish chosen item card.",
+    "body-text": "BREAK: When you play this character, you may banish chosen item.",
     "subtitle": "Hardheaded",
     "image-urls": {
       "small": "https://lorcana-api.com/images/beast/hardheaded/beast-hardheaded-small.png",
@@ -27,7 +27,7 @@
       "foil": "https://lorcana-api.com/images/beast/hardheaded/beast-hardheaded-foil.png"
     },
     "name": "Beast",
-    "flavor-text": "\""She will never se me as anything... but a monster"\"",
+    "flavor-text": "\"She'll never see me as anything... but a monster.\"",
     "ink-cost": 5,
     "rarity": "Uncommon"
   }

--- a/src/data/cards/robin_hood-unrivaled_archer.txt
+++ b/src/data/cards/robin_hood-unrivaled_archer.txt
@@ -14,11 +14,11 @@
     ],
     "set-code": "TFC",
     "abilities": {
-      "Feed The Poor": "When you play this character, if an opponent has more cards in their hand than you, draw a card."
-      "Good Shot": "During your turn, this character has Evasive. (They can challenge characters with Evasive.)"
+      "Feed The Poor": "When you play this character, if an opponent has more cards in their hand than you, draw a card.",
+      "Good Shot": "During your turn, this character gains Evasive. (They can challenge characters with Evasive.)"
     },
     "inkable": true,
-    "body-text": "FEED THE POOR: When you play this character, if an opponent has more cards in their hand than you, draw a card.\nGOOD SHOT: During your turn, this character has Evasive. (They can challenge characters with Evasive.)",
+    "body-text": "FEED THE POOR: When you play this character, if an opponent has more cards in their hand than you, draw a card.\nGOOD SHOT: During your turn, this character gains Evasive. (They can challenge characters with Evasive.)",
     "subtitle": "Unrivaled Archer",
     "image-urls": {
       "small": "https://lorcana-api.com/images/robin_hood/unrivaled_archer/robin_hood-unrivaled_archer-small.png",


### PR DESCRIPTION
I edited the JSON syntax of beast-hardheaded and robin_hood-unrivaled_archer. They should now be found by the API as all the other cards. Also checked all the other values and corrected where necessary.